### PR TITLE
Use new Go.CD yum repo

### DIFF
--- a/manifests/common/repository/debian.pp
+++ b/manifests/common/repository/debian.pp
@@ -17,8 +17,8 @@
 
 class gocd::common::repository::debian (
   $comment     = 'ThoughtWorks GoCD APT Repository',
-  $fingerprint = '9A439A18CBD07C3FF81BCE759149B0A6173454C7',
-  $location    = 'http://dl.bintray.com/gocd/gocd-deb/',
+  $fingerprint = '322259C82D3082B3E32AEC2ED8843F288816C449',
+  $location    = 'https://download.go.cd/',
   $keyserver   = 'pgp.mit.edu',
 ) {
   apt::key { 'thoughtworks-gocd':

--- a/manifests/common/repository/redhat.pp
+++ b/manifests/common/repository/redhat.pp
@@ -17,8 +17,8 @@
 
 class gocd::common::repository::redhat (
   $comment     = 'ThoughtWorks GoCD YUM Repository',
-  $fingerprint = '9A439A18CBD07C3FF81BCE759149B0A6173454C7',
-  $location    = 'http://dl.bintray.com/gocd/gocd-rpm',
+  $fingerprint = '322259C82D3082B3E32AEC2ED8843F288816C449',
+  $location    = 'https://download.go.cd',
   $gpg_key_url = undef,
 ) {
   # Lookup the RPM key from the MIT PGP key server automatically.


### PR DESCRIPTION
Go.CD no longer uses bintray repo for distribution.  It hasn't been update for ages.  

They have new YUM repo now.   

I tested this patch,  works in my environment.   Not submitting patch for Debian because I have no way to test.
